### PR TITLE
Fix PSGallery publish process

### DIFF
--- a/.github/workflows/psgalley-publish.ps1
+++ b/.github/workflows/psgalley-publish.ps1
@@ -1,0 +1,13 @@
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+$ManifestFile = Resolve-Path -Path "*\$ENV:PROJECT_NAME.psd1"
+$ModuleFile = Resolve-Path -Path "*\$ENV:PROJECT_NAME.psm1"
+$ModulePath = Split-Path -Parent $ModuleFile
+$ReleaseNotes = $ENV:RELEASE_NOTES -ireplace "(?s)#{1,} ?Installation.*",""
+Update-ModuleManifest -Path $ManifestFile.Path -ReleaseNotes $ReleaseNotes -ModuleVersion $ENV:RELEASE_VERSION
+Try {
+    Test-ModuleManifest -Path $ManifestFile.Path -ErrorAction Stop
+    Publish-Module -Name $ENV:PROJECT_NAME -Path $ModulePath -NuGetApiKey $ENV:PSGALLERY_APIKEY -Force -ErrorAction Stop
+}
+Catch {
+    Throw "Unable to publish module: $_"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 jobs:
-  milestone:
+  grm:
     runs-on: ubuntu-latest
     steps:
     - name: Install GitReleaseManager
@@ -16,16 +16,21 @@ jobs:
       uses: gittools/actions/gitreleasemanager/close@v0.9.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        owner: 'leojackson'
-        repository: 'PsLogLite'
-        milestone: ${{ env.GITHUB_REF }}
+        owner: ${{ github.repository_owner }}
+        repository: ${{ github.event.repository.name }}
+        milestone: ${{ github.event.release.tag_name }}
+    - name: Export release notes for use in PSD1 file
+      uses: gittools/actions/gitreleasemanager/export@v0.9.2
   psgallery:
     runs-on: windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Push package to PSGallery
+    - name: Publish package to PowerShell Gallery
       env:
         PSGALLERY_APIKEY: ${{ secrets.PSGALLERY_APIKEY }}
-      run: Publish-Module -Path ".\PsLogLite" -NuGetApiKey "$ENV:PSGALLERY_APIKEY"
-      shell: powershell
+        PROJECT_NAME: ${{ github.event.repository.name }}
+        RELEASE_NOTES: ${{ github.event.release.body }}
+        RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      run: .github\workflows\psgallery-publish.ps1
+      shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
       uses: gittools/actions/gitreleasemanager/create@v0.9.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        owner: 'leojackson'
-        repository: 'PsLogLite'
+        owner: ${{ github.repository_owner }}
+        repository: ${{ github.event.repository.name }}
         milestone: ${{ steps.gitversion.outputs.semVer }}
         name: ${{ steps.gitversion.outputs.semVer }}
         assets: |

--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -1,0 +1,56 @@
+# Configuration values used when creating new releases
+create:
+  include-footer: true
+  footer-heading: Installation
+  footer-content: >-
+    PsLogLite is available in the PowerShell Gallery
+    ```powershell
+    Install-Module PsLogLite -MinimumVersion {milestone}
+    ```
+    Please review the [documentation](https://leojackson.github.io/PsLogLite/) and submit any bugs, feature requests, etc via the project's [issues](https://github.com/leojackson/PsLogLite/issues) page.
+  footer-includes-milestone: false
+  milestone-replace-text: '{milestone}'
+  include-sha-section: false
+  sha-section-heading: SHA256 Hashes of the release artifacts
+  sha-section-line-format: '- `{1}	{0}`'
+  allow-update-to-published: false
+
+# Configuration values used when exporting release notes
+export:
+  include-created-date-in-title: false
+  created-date-string-format: MMMM dd, yyyy
+  perform-regex-removal: true
+  regex-text: '### Where to get it(\r\n)*You can .*\.'
+  multiline-regex: true
+
+# Configuration values used when closing a milestone
+close:
+  # Whether to add comments to issues closed and with the published milestone release.
+  use-issue-comments: true
+  issue-comment: |-
+    :tada: This issue has been resolved in version {milestone} :tada:
+
+    The release is available on:
+    - [PowerShell Gallery](https://www.powershellgallery.com/packages/{repository}/{milestone})
+    - [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
+
+    Your **[GitReleaseManager](https://github.com/GitTools/GitReleaseManager)** bot :package::rocket:
+# The labels that will be used to include issues in release notes.
+issue-labels-include:
+  - Bug
+  - Duplicate
+  - Enhancement
+  - Feature
+  - Help Wanted
+  - Improvement
+  - Invalid
+  - Question
+  - WontFix
+# The labels that will NOT be used when including issues in release notes.
+issue-labels-exclude:
+  - Internal Refactoring
+# Overrides default pluralization and header names for specific labels.
+issue-labels-alias:
+  - name: Documentation
+    header: Documentation
+    plural: Documentation

--- a/PsLogLite/PsLogLite.psd1
+++ b/PsLogLite/PsLogLite.psd1
@@ -129,7 +129,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        # ReleaseNotes = 'Release Notes Placeholder'
 
         # Prerelease string of this module
         # Prerelease = ''


### PR DESCRIPTION
**What type of PR is this? (feature, improvement, bugfix, etc)**
Bug: Fixing PSGallery publich process so it will actually work

**What does this PR do?**
* Adds GitReleaseManager.yaml file
* Splits out PSGallery publish PowerShell to its own script
* Fixes syntax errors