### PR TITLE
Upd versionSpec for gitversion, rm commented lines

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,5 @@ jobs:
         echo RELEASE_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       shell: pwsh
     - name: Publish package to PowerShell Gallery
-      # env:
-      #   PSGALLERY_APIKEY: ${{ secrets.PSGALLERY_APIKEY }}
-      #   PROJECT_NAME: ${{ github.event.repository.name }}
-      #   RELEASE_NOTES: ${{ github.event.release.body }}
-      #   RELEASE_VERSION: ${{ github.event.release.tag_name }}
       run: .github\workflows\psgallery-publish.ps1
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.13
       with:
-        versionSpec: '5.2.x'
+        versionSpec: '5.x'
     - name: Use GitVersion
       id: gitversion
       uses: gittools/actions/gitversion/execute@v0.9.13
@@ -32,9 +32,6 @@ jobs:
         echo RELEASE_VERSION=${{ steps.gitversion.outputs.semVer }} >> $GITHUB_ENV
       shell: powershell
     - name: Create artifact
-      # env:
-      #   PROJECT_NAME: ${{ github.event.repository.name }}
-      #   RELEASE_VERSION: ${{ steps.gitversion.outputs.semVer }}
       run: .github\workflows\create-artifact.ps1
       shell: powershell
     - name: Create release


### PR DESCRIPTION
**What type of PR is this? (feature, improvement, bugfix, etc)**
> Fix for #37 

**What does this PR do?**
> Updates vulnerable Git Actions

**Which issue (or issues) does this PR fix?**
> Fixes #37 - [CVE-2021-33623](https://github.com/advisories/GHSA-7p7h-4mm5-852v)

**Special notes for the reviewer**
> Updating gitversion versionSpec after GitHub Actions upgrade from 0.9.2 to 0.9.13

**Does this PR introduce a user-facing change?**:
No, pipeline actions only
